### PR TITLE
Add broker rack awareness config properties

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -269,6 +269,8 @@ default.kkafka.broker[:log][:cleaner][:enable]                         = "true"
 default.kkafka.broker[:log][:cleaner][:io][:buffer][:load][:factor]    = "0.9"
 # values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
 default.kkafka.broker[:security][:inter][:broker][:protocol]           = "PLAINTEXT"
+default.kkafka.broker[:inter][:broker][:protocol][:version]            = "#{node.kkafka.version}"
+default.kkafka.broker[:broker][:rack]                                  = "hdp1"
 # required, requested, none
 default.kkafka.broker[:ssl][:client][:auth]                            = "requested"
 default.kkafka.broker[:ssl][:keystore][:location]                      = "#{node.kagent.certs_dir}/keystores/node_server_keystore.jks"

--- a/metadata.rb
+++ b/metadata.rb
@@ -225,6 +225,14 @@ attribute "kkafka/broker/security/inter/broker/protocol",
           :description => "",
           :type => 'string'
 
+attribute "kkafka/inter/broker/protocol/version",
+          :description => "",
+          :type => 'string'
+
+attribute "kkafka/broker/rack",
+          :description => "",
+          :type => 'string'
+
 attribute "kkafka/broker/ssl/client/auth",
           :description => "",
           :type => 'string'


### PR DESCRIPTION
As per Kafka 0.10, brokers can me made rack aware. From [KIP-36](https://cwiki.apache.org/confluence/display/KAFKA/KIP-36+Rack+aware+replica+assignment):
 "_In Kafka, if there are more than one replica for a partition, it would be nice to have replicas placed in as many different racks as possible so that the partition can continue to function if a rack goes down. In addition, it makes maintenance of  Kafka cluster easier as you can take down the whole rack at a time._" 
